### PR TITLE
test: add test project setup (xUnit, Moq, coverlet)

### DIFF
--- a/tests/CurrencyConverter.Tests/CurrencyConverter.Tests.csproj
+++ b/tests/CurrencyConverter.Tests/CurrencyConverter.Tests.csproj
@@ -1,0 +1,28 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="Moq" Version="4.20.72" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\TrocaMoedas.Application\TrocaMoedas.Application.csproj" />
+    <ProjectReference Include="..\..\src\TrocaMoedas.Domain\TrocaMoedas.Domain.csproj" />
+    <ProjectReference Include="..\..\src\TrocaMoedas.Infrastructure\TrocaMoedas.Infrastructure.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/CurrencyConverter.Tests/PlaceholderTests.cs
+++ b/tests/CurrencyConverter.Tests/PlaceholderTests.cs
@@ -1,0 +1,10 @@
+namespace CurrencyConverter.Tests;
+
+public class PlaceholderTests
+{
+    [Fact]
+    public void Solution_ShouldCompile_AndTestShouldPass()
+    {
+        Assert.True(true);
+    }
+}

--- a/troca-moedas.sln
+++ b/troca-moedas.sln
@@ -10,6 +10,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TrocaMoedas.Domain", "src\T
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TrocaMoedas.Infrastructure", "src\TrocaMoedas.Infrastructure\TrocaMoedas.Infrastructure.csproj", "{D4E5F6A7-B8C9-0123-DEFG-234567890123}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CurrencyConverter.Tests", "tests\CurrencyConverter.Tests\CurrencyConverter.Tests.csproj", "{E6F7A8B9-C0D1-2345-EF67-890123456789}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -32,6 +34,10 @@ Global
 		{D4E5F6A7-B8C9-0123-DEFG-234567890123}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{D4E5F6A7-B8C9-0123-DEFG-234567890123}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D4E5F6A7-B8C9-0123-DEFG-234567890123}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E6F7A8B9-C0D1-2345-EF67-890123456789}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E6F7A8B9-C0D1-2345-EF67-890123456789}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E6F7A8B9-C0D1-2345-EF67-890123456789}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E6F7A8B9-C0D1-2345-EF67-890123456789}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
## Descrição
Configura o projeto de testes com todas as dependências necessárias para a Sprint 2.

## Mudanças
- [x] Projeto  criado com target 
- [x] NuGet: xUnit, xUnit.runner.visualstudio, Moq, coverlet.collector, Microsoft.NET.Test.Sdk
- [x] Referências: TrocaMoedas.Application, TrocaMoedas.Domain, TrocaMoedas.Infrastructure
- [x] Adicionado ao 
- [x] Estrutura de pastas: Services/, Data/, Commands/
- [x] Placeholder test validando o setup

## Critério de Aceite
- [x]  compila sem erros
- [x]  executa (mesmo com placeholder)

## Referência
Closes #10 (P-02-01)
Sprint 2 — Cache & Testes